### PR TITLE
Refactor index builder and modernize macro path handling

### DIFF
--- a/PartsLibrary.FCMacro
+++ b/PartsLibrary.FCMacro
@@ -22,7 +22,6 @@
 #*   USA                                                                   *
 #*                                                                         *
 #***************************************************************************
-from __future__ import print_function
 
 __title__="FreeCAD Parts Library Macro"
 __author__ = "Yorik van Havre"
@@ -75,24 +74,24 @@ considered when pushing, so you can place private Parts there.
 
 
 import sys, FreeCAD, FreeCADGui, Part, zipfile, tempfile, Mesh, os, subprocess
+from pathlib import Path
 from PySide import QtGui, QtCore
 
 param = FreeCAD.ParamGet('User parameter:Plugins/parts_library')
 s = param.GetString('destination')
 #print('User parameter:Plugins/partlib : destination : ',s)
 
-try:
-    QtCore.QTextCodec.setCodecForTr(QTextCodec.codecForName("UTF-8"))
-except:
-    pass # Will fallback to Latin-1
-
 if s:
-    LIBRARYPATH = s
+    LIBRARYPATH = Path(s)
 else:
 
-    folderDialog = QtGui.QFileDialog.getExistingDirectory(None,QtGui.QApplication.translate("PartsLibrary", "Location of your existing Parts library"))
-    param.SetString('destination',folderDialog.replace("\\","/")) # forward slashes apparently work on windows too
-    LIBRARYPATH = param.GetString('destination')
+    folderDialog = QtGui.QFileDialog.getExistingDirectory(None, QtGui.QApplication.translate("PartsLibrary", "Location of your existing Parts library"))
+    if not folderDialog:
+        QtGui.QMessageBox.warning(None, "PartsLibrary", "No folder selected. Macro will exit.")
+        raise SystemExit
+    param.SetString('destination', folderDialog.replace("\\","/")) # forward slashes apparently work on windows too
+    LIBRARYPATH = Path(param.GetString('destination'))
+LIBRARYPATH = Path(LIBRARYPATH)
 
 
 def translate(context, text):
@@ -116,14 +115,14 @@ class ExpFileSystemModel(QtGui.QFileSystemModel):
 class ExpDockWidget(QtGui.QDockWidget):
     "a library explorer dock widget"
 
-    def __init__(self,LIBRARYPATH):
+    def __init__(self,LIBRARYPATH: Path):
         QtGui.QDockWidget.__init__(self)
 
         self.setObjectName("PartsLibrary")
 
         # setting up a directory model that shows only fcstd, step and brep
         self.dirmodel = ExpFileSystemModel()
-        self.dirmodel.setRootPath(LIBRARYPATH)
+        self.dirmodel.setRootPath(str(LIBRARYPATH))
         self.dirmodel.setNameFilters(["*.fcstd","*.FcStd","*.FCSTD","*.stp","*.STP","*.step","*.STEP", "*.brp", "*.BRP", "*.brep", "*.BREP"])
         self.dirmodel.setNameFilterDisables(0)
 
@@ -136,7 +135,7 @@ class ExpDockWidget(QtGui.QDockWidget):
         self.folder.hideColumn(1)
         self.folder.hideColumn(2)
         self.folder.hideColumn(3)
-        self.folder.setRootIndex(self.dirmodel.index(LIBRARYPATH))
+        self.folder.setRootIndex(self.dirmodel.index(str(LIBRARYPATH)))
         
         self.preview = QtGui.QLabel()
         self.preview.setFixedHeight(128)
@@ -213,7 +212,7 @@ class ExpDockWidget(QtGui.QDockWidget):
             FreeCAD.Console.PrintWarning("python-git not found. Git-related functions will be disabled\n")
         else:
             try:
-                repo = git.Repo(LIBRARYPATH)
+                repo = git.Repo(str(LIBRARYPATH))
             except:
                 FreeCAD.Console.PrintWarning("Your library is not a valid Git repository. Git-related functions will be disabled\n")
             else:
@@ -267,7 +266,7 @@ class ExpDockWidget(QtGui.QDockWidget):
         FreeCADGui.SendMsgToActiveView("ViewFit")
 
     def addtolibrary(self):
-        fileDialog = QtGui.QFileDialog.getSaveFileName(None,u"Choose category and set a filename without extension", LIBRARYPATH)
+        fileDialog = QtGui.QFileDialog.getSaveFileName(None, u"Choose category and set a filename without extension", str(LIBRARYPATH))
         if fileDialog != '':
             #filename = fileDialog[0].split("/")[-1]
             #if filename.split(".")[-1].lowercase == "fcstd" or "stl
@@ -445,7 +444,7 @@ class ConfigDialog(QtGui.QDialog):
             FreeCAD.ParamGet('User parameter:Plugins/parts_library').SetString('destination',self.lineEdit_3.text())
         QtGui.QDialog.accept(self)
 
-if QtCore.QDir(LIBRARYPATH).exists():
+if QtCore.QDir(str(LIBRARYPATH)).exists():
     m = FreeCADGui.getMainWindow()
     w = m.findChild(QtGui.QDockWidget,"PartsLibrary")
     if w:

--- a/index_template.html
+++ b/index_template.html
@@ -1,0 +1,132 @@
+<html>
+    <head>
+        <title>FreeCAD Library</title>
+        <style>
+body {
+    font-family: Arial,sans;
+    color: black;
+    background: white;
+}
+a:link, a:visited {
+    color: black;
+    text-decoration: none;
+}
+img {
+    width: 16px;
+}
+h1, h2, h3, h4, h5, h6, .h7, .h8, .h9 {
+    clear: both;
+    margin: 0;
+    cursor: pointer;
+    font-size: 1em;
+}
+.collapsable {
+    border-left: 1px solid grey;
+    padding-left: 8px;
+    margin-left: 5px;
+}
+.cards {
+    margin: 0;
+}
+.card {
+    float:left;
+    width: 128px;
+    margin: 4px;
+}
+.icon {
+    width: 128px;
+}
+.hicon {
+    width: 12px;
+    margin-right: 4px;
+}
+.name {
+    clear: left;
+    float: left;
+    overflow-wrap: break-word;
+    width: 128px;
+}
+.links {
+    float: left;
+}
+.fullwidth {
+    width: 100% !important;
+}
+.smallicon {
+    width: 16px !important;
+    margin-right: 8px;
+    float: left !important;
+}
+.largetext {
+    clear: none !important;
+    width: auto !important;
+    margin-right: 8px;
+}
+.hidden {
+    display: none;
+}
+.iconselected {
+    border: 2px solid black;
+}
+        </style>
+        <script>
+function seticon() {
+    collection = document.getElementsByClassName("card");
+    for (let i = 0; i < collection.length; i++) {
+        collection[i].classList.remove("fullwidth")
+    }
+    collection = document.getElementsByClassName("icon");
+    for (let i = 0; i < collection.length; i++) {
+        collection[i].classList.remove("smallicon")
+    }
+    collection = document.getElementsByClassName("name");
+    for (let i = 0; i < collection.length; i++) {
+        collection[i].classList.remove("largetext")
+    }
+    icon_icon = document.getElementById("icon_icon");
+    icon_icon.classList.add("iconselected")
+    icon_grid = document.getElementById("icon_grid");
+    icon_grid.classList.remove("iconselected")
+}
+function setgrid() {
+    collection = document.getElementsByClassName("card");
+    for (let i = 0; i < collection.length; i++) {
+      collection[i].classList.add("fullwidth")
+    }
+    collection = document.getElementsByClassName("icon");
+    for (let i = 0; i < collection.length; i++) {
+        collection[i].classList.add("smallicon")
+    }
+    collection = document.getElementsByClassName("name");
+    for (let i = 0; i < collection.length; i++) {
+        collection[i].classList.add("largetext")
+    }
+    icon_icon = document.getElementById("icon_icon");
+    icon_icon.classList.remove("iconselected")
+    icon_grid = document.getElementById("icon_grid");
+    icon_grid.classList.add("iconselected")
+}
+function collapse(elt) {
+    ndiv = elt.parentElement.nextSibling.nextSibling;
+    if (ndiv.classList.contains("hidden")) {
+        elt.src = "<!--expandicon-->";
+        ndiv.classList.remove("hidden");
+    } else {
+        elt.src = "<!--collapseicon-->";
+        ndiv.classList.add("hidden");
+    }
+}
+        </script>
+    </head>
+    <body>
+        <div class="nav">
+            <a id="icon_icon" class="navicon iconselected" href="#" title="icon view" onclick="seticon()">
+                <img src="<!--gridicon-->"/>
+            </a>
+            <a id="icon_grid" class="navicon" href="#" title="list view" onclick="setgrid()">
+                <img src="<!--listicon-->"/>
+            </a>
+        </div>
+<!--contents-->
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- refactor build_index.py to use pathlib, external HTML template, and basic error handling
- remove legacy Python 2 code in PartsLibrary.FCMacro and handle user cancel when selecting library path
- store template in new index_template.html file

## Testing
- `python -m py_compile build_index.py`
- `python -m py_compile PartsLibrary.FCMacro`


------
https://chatgpt.com/codex/tasks/task_e_68ae89fd8d008332b69192a0119ba39b